### PR TITLE
Print xunit XML output

### DIFF
--- a/bin/spacejam-xunit
+++ b/bin/spacejam-xunit
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+spacejam test-packages ./ | sed -ne 's/^##_meteor_magic##xunit: //p'

--- a/bin/spacejam-xunit
+++ b/bin/spacejam-xunit
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -o errexit
 set -o nounset
-spacejam test-packages ./ | sed -ne 's/^##_meteor_magic##xunit: //p'
+spacejam test-packages --platform xunit $@ | sed -ne 's/^##_meteor_magic##xunit: //p'

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "bin": {
     "spacejam": "bin/spacejam",
+    "spacejam-xunit": "bin/spacejam-xunit",
     "mrun": "bin/meteor-run.sh",
     "mtp": "bin/meteor-test-packages.sh"
   },


### PR DESCRIPTION
Seems clunky to use another shell script, but I'm still not quite sure how to work this into the main spacejam code.

Oh, here's an idea... in src/phantomjs-test-in-console.coffee log lines to test-output.xml if they match /^##_meteor_magic##xunit: / ??

... hrm, I'm unable to write to a file in page.onConsoleMessage (in src/phantomjs-test-in-console.coffee). Maybe I'd need to use the HTML5 FileSystem API? Not sure.