### PR TITLE
Add mocha support

### DIFF
--- a/lib/Meteor.js
+++ b/lib/Meteor.js
@@ -81,14 +81,14 @@
       cwd = path.resolve(this.options.dir);
       log.debug("meteor cwd=" + cwd);
       expect(this.options['driver-package'], "options.driver-package is missing").to.be.ok;
+      if (this.options.mocha != null) {
+        this.options["driver-package"] = "practicalmeteor:mocha-console-runner";
+      }
       expect(+this.options.port, "options.port is not a number.").to.be.ok;
       if ((_base = this.options)["root-url"] == null) {
         _base["root-url"] = "http://localhost:" + this.options.port + "/";
       }
       expect(this.options.packages, "options.packages is not an array of package names").to.be.an('array');
-      if (this.options.mocha != null) {
-        this.options["driver-package"] = "practicalmeteor:mocha-console-reporter";
-      }
       if (this.options.packages.length > 0) {
         packagesToTest = this._globPackages(this.options.packages);
         expect(packagesToTest).to.have.length.above(0);

--- a/lib/Meteor.js
+++ b/lib/Meteor.js
@@ -86,6 +86,9 @@
         _base["root-url"] = "http://localhost:" + this.options.port + "/";
       }
       expect(this.options.packages, "options.packages is not an array of package names").to.be.an('array');
+      if (this.options.mocha != null) {
+        this.options["driver-package"] = "practicalmeteor:mocha-console-reporter";
+      }
       if (this.options.packages.length > 0) {
         packagesToTest = this._globPackages(this.options.packages);
         expect(packagesToTest).to.have.length.above(0);

--- a/lib/phantomjs-test-in-console.js
+++ b/lib/phantomjs-test-in-console.js
@@ -15,6 +15,13 @@
   page.open(system.env.ROOT_URL);
 
   page.onError = function(msg, trace) {
+    var mochaIsRunning;
+    mochaIsRunning = page.evaluate(function() {
+      return mochaIsRunning;
+    });
+    if (mochaIsRunning) {
+      return;
+    }
     console.log("phantomjs: " + msg);
     trace.forEach(function(item) {
       return console.log("    " + item.file + ": " + item.line);

--- a/src/Meteor.coffee
+++ b/src/Meteor.coffee
@@ -66,14 +66,14 @@ class Meteor extends EventEmitter
 
     expect(@options['driver-package'], "options.driver-package is missing").to.be.ok
 
+    if @options.mocha?
+      @options["driver-package"] = "practicalmeteor:mocha-console-runner"
+
     expect(+@options.port, "options.port is not a number.").to.be.ok
 
     @options["root-url"] ?= "http://localhost:#{@options.port}/"
 
     expect(@options.packages, "options.packages is not an array of package names").to.be.an 'array'
-
-    if @options.mocha?
-      @options["driver-package"] = "practicalmeteor:mocha-console-reporter"
 
     if @options.packages.length > 0
       packagesToTest = @_globPackages(@options.packages)

--- a/src/Meteor.coffee
+++ b/src/Meteor.coffee
@@ -72,6 +72,9 @@ class Meteor extends EventEmitter
 
     expect(@options.packages, "options.packages is not an array of package names").to.be.an 'array'
 
+    if @options.mocha?
+      @options["driver-package"] = "practicalmeteor:mocha-console-reporter"
+
     if @options.packages.length > 0
       packagesToTest = @_globPackages(@options.packages)
       expect(packagesToTest).to.have.length.above 0

--- a/src/phantomjs-test-in-console.coffee
+++ b/src/phantomjs-test-in-console.coffee
@@ -9,7 +9,15 @@ page.onConsoleMessage = (message) ->
 page.open(system.env.ROOT_URL)
 
 page.onError = (msg, trace) ->
+
+  mochaIsRunning = page.evaluate ->
+    return mochaIsRunning
+  # Mocha will handle the error for us
+  if mochaIsRunning
+    return
+
   console.log("phantomjs: #{msg}")
+
   trace.forEach((item) ->
     console.log("    #{item.file}: #{item.line}")
   )

--- a/src/phantomjs-test-in-console.coffee
+++ b/src/phantomjs-test-in-console.coffee
@@ -12,7 +12,8 @@ page.onError = (msg, trace) ->
 
   mochaIsRunning = page.evaluate ->
     return mochaIsRunning
-  # Mocha will handle the error for us
+
+  # Mocha will handle and report the uncaught errors for us
   if mochaIsRunning
     return
 


### PR DESCRIPTION
Add support for --mocha=true flag that translates into --driver-package=practicalmeteor:mocha-console-runner

Let mocha handle and report uncaught client side errors, while mocha tests are running.